### PR TITLE
Add support for FP32 master weights in FusedAdam optimizer

### DIFF
--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -146,10 +146,11 @@ class FusedAdam(torch.optim.Optimizer):
             p_16_model = []
 
             for pi, p in enumerate(group['params']):
-                if p.grad is None and not self.use_master:
-                    continue
-                if p.grad.data.is_sparse:
-                    raise RuntimeError('FusedAdam does not support sparse gradients, please consider SparseAdam instead')
+                if not self.use_master:
+                    if p.grad is None:
+                        continue
+                    if p.grad.data.is_sparse:
+                        raise RuntimeError('FusedAdam does not support sparse gradients, please consider SparseAdam instead')
 
                 state = self.state[p]
                 # State initialization

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -155,9 +155,7 @@ class FusedAdam(torch.optim.Optimizer):
 
                 if p.dtype == torch.float16:
                     if self.use_master:
-                        master_p = self.master_params[pi]
-                        assert(p.data.size() == master_p.data.size())
-                        p_32_master.append(master_p)
+                        p_32_master.append(self.master_params[pi])
                     g_16.append(p.grad.data)
                     p_16.append(p.data)
                     m_16.append(state['exp_avg'].float())

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -196,6 +196,15 @@ class FusedAdam(torch.optim.Optimizer):
 
                 if len(g_16) > 0:
                     if self.use_master:
+                        for pppi, ppp in enumerate(p_16):
+                            if ppp.size() == torch.Size([16, 6, 5, 5]):
+                                print("BEFORE MTA")
+                                print("p_16:", p_16[pppi][0][5][2][1])
+                                print("g_16:", g_16[pppi][0][5][2][1])
+                                print("m_16:", m_16[pppi][0][5][2][1])
+                                print("v_16:", v_16[pppi][0][5][2][1])
+                                print("p_32_master:", p_32_master[pppi][0][5][2][1])
+
                         multi_tensor_applier(self.multi_tensor_adam_capturable_2,
                                 self._dummy_overflow_buf,
                                 [g_16, p_16, m_16, v_16, p_32_master],
@@ -208,6 +217,15 @@ class FusedAdam(torch.optim.Optimizer):
                                 bias_correction,
                                 group['weight_decay'],
                                 inv_scale)
+
+                        for pppi, ppp in enumerate(p_16):
+                            if ppp.size() == torch.Size([16, 6, 5, 5]):
+                                print("AFTER MTA")
+                                print("p_16:", p_16[pppi][0][5][2][1])
+                                print("g_16:", g_16[pppi][0][5][2][1])
+                                print("m_16:", m_16[pppi][0][5][2][1])
+                                print("v_16:", v_16[pppi][0][5][2][1])
+                                print("p_32_master:", p_32_master[pppi][0][5][2][1])
                     else:
                         multi_tensor_applier(self.multi_tensor_adam_capturable,
                                 self._dummy_overflow_buf,
@@ -238,6 +256,14 @@ class FusedAdam(torch.optim.Optimizer):
                             inv_scale)
 
                 if len(g_32) > 0:
+                    for pppi, ppp in enumerate(p_32):
+                        if ppp.size() == torch.Size([16, 6, 5, 5]):
+                            print("BEFORE MTA")
+                            print("p_32:", p_32[pppi][0][5][2][1])
+                            print("g_32:", g_32[pppi][0][5][2][1])
+                            print("m_32:", m_32[pppi][0][5][2][1])
+                            print("v_32:", v_32[pppi][0][5][2][1])
+
                     multi_tensor_applier(self.multi_tensor_adam_capturable,
                             self._dummy_overflow_buf,
                             [g_32, p_32, m_32, v_32],
@@ -250,6 +276,14 @@ class FusedAdam(torch.optim.Optimizer):
                             bias_correction,
                             group['weight_decay'],
                             inv_scale)
+
+                        if ppp.size() == torch.Size([16, 6, 5, 5]):
+                            print("AFTER MTA")
+                            print("p_32:", p_32[pppi][0][5][2][1])
+                            print("g_32:", g_32[pppi][0][5][2][1])
+                            print("m_32:", m_32[pppi][0][5][2][1])
+                            print("v_32:", v_32[pppi][0][5][2][1])
+
             else:
                 if len(g_16) > 0:
                     multi_tensor_applier(self.multi_tensor_adam,

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -196,15 +196,6 @@ class FusedAdam(torch.optim.Optimizer):
 
                 if len(g_16) > 0:
                     if self.use_master:
-                        for pppi, ppp in enumerate(p_16):
-                            if ppp.size() == torch.Size([16, 6, 5, 5]):
-                                print("BEFORE MTA")
-                                print("p_16:", p_16[pppi][0][5][2][1])
-                                print("g_16:", g_16[pppi][0][5][2][1])
-                                print("m_16:", m_16[pppi][0][5][2][1])
-                                print("v_16:", v_16[pppi][0][5][2][1])
-                                print("p_32_master:", p_32_master[pppi][0][5][2][1])
-
                         multi_tensor_applier(self.multi_tensor_adam_capturable_2,
                                 self._dummy_overflow_buf,
                                 [g_16, p_16, m_16, v_16, p_32_master],
@@ -217,15 +208,6 @@ class FusedAdam(torch.optim.Optimizer):
                                 bias_correction,
                                 group['weight_decay'],
                                 inv_scale)
-
-                        for pppi, ppp in enumerate(p_16):
-                            if ppp.size() == torch.Size([16, 6, 5, 5]):
-                                print("AFTER MTA")
-                                print("p_16:", p_16[pppi][0][5][2][1])
-                                print("g_16:", g_16[pppi][0][5][2][1])
-                                print("m_16:", m_16[pppi][0][5][2][1])
-                                print("v_16:", v_16[pppi][0][5][2][1])
-                                print("p_32_master:", p_32_master[pppi][0][5][2][1])
                     else:
                         multi_tensor_applier(self.multi_tensor_adam_capturable,
                                 self._dummy_overflow_buf,
@@ -256,14 +238,6 @@ class FusedAdam(torch.optim.Optimizer):
                             inv_scale)
 
                 if len(g_32) > 0:
-                    for pppi, ppp in enumerate(p_32):
-                        if ppp.size() == torch.Size([16, 6, 5, 5]):
-                            print("BEFORE MTA")
-                            print("p_32:", p_32[pppi][0][5][2][1])
-                            print("g_32:", g_32[pppi][0][5][2][1])
-                            print("m_32:", m_32[pppi][0][5][2][1])
-                            print("v_32:", v_32[pppi][0][5][2][1])
-
                     multi_tensor_applier(self.multi_tensor_adam_capturable,
                             self._dummy_overflow_buf,
                             [g_32, p_32, m_32, v_32],
@@ -276,15 +250,6 @@ class FusedAdam(torch.optim.Optimizer):
                             bias_correction,
                             group['weight_decay'],
                             inv_scale)
-
-                    for pppi, ppp in enumerate(p_32):
-                        if ppp.size() == torch.Size([16, 6, 5, 5]):
-                            print("AFTER MTA")
-                            print("p_32:", p_32[pppi][0][5][2][1])
-                            print("g_32:", g_32[pppi][0][5][2][1])
-                            print("m_32:", m_32[pppi][0][5][2][1])
-                            print("v_32:", v_32[pppi][0][5][2][1])
-
             else:
                 if len(g_16) > 0:
                     multi_tensor_applier(self.multi_tensor_adam,

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -160,8 +160,8 @@ class FusedAdam(torch.optim.Optimizer):
                         p_32_master.append(master_p)
                     g_16.append(p.grad.data)
                     p_16.append(p.data)
-                    m_16.append(state['exp_avg'])
-                    v_16.append(state['exp_avg_sq'])
+                    m_16.append(state['exp_avg'].float())
+                    v_16.append(state['exp_avg_sq'].float())
                 elif p.dtype == torch.bfloat16:
                     g_bf.append(p.grad)
                     p_bf.append(p)

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -149,9 +149,9 @@ class FusedAdam(torch.optim.Optimizer):
                 # State initialization
                 if len(state) == 0:
                     # Exponential moving average of gradient values
-                    state['exp_avg'] = torch.zeros_like(p.data)
+                    state['exp_avg'] = torch.zeros_like(p.data).float()
                     # Exponential moving average of squared gradient values
-                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+                    state['exp_avg_sq'] = torch.zeros_like(p.data).float()
 
                 if p.dtype == torch.float16:
                     if self.use_master:

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -277,6 +277,7 @@ class FusedAdam(torch.optim.Optimizer):
                             group['weight_decay'],
                             inv_scale)
 
+                    for pppi, ppp in enumerate(p_32):
                         if ppp.size() == torch.Size([16, 6, 5, 5]):
                             print("AFTER MTA")
                             print("p_32:", p_32[pppi][0][5][2][1])

--- a/apex/optimizers/fused_adam.py
+++ b/apex/optimizers/fused_adam.py
@@ -96,6 +96,7 @@ class FusedAdam(torch.optim.Optimizer):
             self._dummy_overflow_buf = torch.cuda.IntTensor([0])
             self.multi_tensor_adam = amp_C.multi_tensor_adam
             self.multi_tensor_adam_capturable = amp_C.multi_tensor_adam_capturable
+            self.multi_tensor_adam_capturable_2 = amp_C.multi_tensor_adam_capturable_2
         else:
             raise RuntimeError('apex.optimizers.FusedAdam requires cuda extensions')
 

--- a/csrc/amp_C_frontend.cpp
+++ b/csrc/amp_C_frontend.cpp
@@ -95,7 +95,7 @@ void multi_tensor_adam_capturable_cuda(
   const float weight_decay,
   at::Tensor inv_scale);
 
-void multi_tensor_adam_capturable_cuda_2(
+void multi_tensor_adam_capturable_master_cuda(
   int chunk_size,
   at::Tensor noop_flag,
   std::vector<std::vector<at::Tensor>> tensor_lists,
@@ -192,8 +192,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Compute and apply gradient update to parameters for Adam optimizer");
   m.def("multi_tensor_adam_capturable", &multi_tensor_adam_capturable_cuda,
         "Compute and apply gradient update to parameters for Adam optimizer with CUDA graph support and LR scheduling");
-  m.def("multi_tensor_adam_capturable_2", &multi_tensor_adam_capturable_cuda_2,
-        "Compute and apply gradient update to parameters for Adam optimizer with CUDA graph support and LR scheduling");
+  m.def("multi_tensor_adam_capturable_master", &multi_tensor_adam_capturable_master_cuda,
+        "Compute and apply gradient update to parameters for Adam optimizer with CUDA graph support, LR scheduling and FP32 master weights");
   m.def("multi_tensor_adagrad", &multi_tensor_adagrad_cuda,
         "Compute and apply gradient update to parameters for Adam optimizer");
   m.def("multi_tensor_novograd", &multi_tensor_novograd_cuda,

--- a/csrc/amp_C_frontend.cpp
+++ b/csrc/amp_C_frontend.cpp
@@ -95,6 +95,20 @@ void multi_tensor_adam_capturable_cuda(
   const float weight_decay,
   at::Tensor inv_scale);
 
+void multi_tensor_adam_capturable_cuda_2(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  at::Tensor lr,
+  const float beta1,
+  const float beta2,
+  const float epsilon,
+  at::Tensor step,
+  const int mode,
+  const int bias_correction,
+  const float weight_decay,
+  at::Tensor inv_scale);
+
 void multi_tensor_adagrad_cuda(
   int chunk_size,
   at::Tensor noop_flag,
@@ -177,6 +191,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("multi_tensor_adam", &multi_tensor_adam_cuda,
         "Compute and apply gradient update to parameters for Adam optimizer");
   m.def("multi_tensor_adam_capturable", &multi_tensor_adam_capturable_cuda,
+        "Compute and apply gradient update to parameters for Adam optimizer with CUDA graph support and LR scheduling");
+  m.def("multi_tensor_adam_capturable_2", &multi_tensor_adam_capturable_cuda_2,
         "Compute and apply gradient update to parameters for Adam optimizer with CUDA graph support and LR scheduling");
   m.def("multi_tensor_adagrad", &multi_tensor_adagrad_cuda,
         "Compute and apply gradient update to parameters for Adam optimizer");

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -190,10 +190,9 @@ struct AdamCapturableFunctor
         if(i < n && i < chunk_size)
         {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
-          g[i] = r_g[ii];
-          r_p[ii] = p[i];
-          r_m[ii] = m[i];
-          r_v[ii] = v[i];
+          r_p[ii] = static_cast<MATH_T>(p[i]);
+          r_m[ii] = static_cast<MATH_T>(m[i]);
+          r_v[ii] = static_cast<MATH_T>(v[i]);
         } else {
           r_g[ii] = MATH_T(0);
           r_p[ii] = MATH_T(0);
@@ -230,9 +229,10 @@ struct AdamCapturableFunctor
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-          p[i] = r_p[ii];
-          m[i] = r_m[ii];
-          v[i] = r_v[ii];
+          g[i] = static_cast<T>(r_g[ii]);
+          p[i] = static_cast<T>(r_p[ii]);
+          m[i] = static_cast<T>(r_m[ii]);
+          v[i] = static_cast<T>(r_v[ii]);
         }
       }
     }
@@ -306,10 +306,9 @@ struct AdamCapturableFunctor2
         if(i < n && i < chunk_size)
         {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
-          g[i] = r_g[ii];
-          r_p[ii] = p_master[i];
-          r_m[ii] = m[i];
-          r_v[ii] = v[i];
+          r_p[ii] = static_cast<MATH_T>(p_master[i]);
+          r_m[ii] = static_cast<MATH_T>(m[i]);
+          r_v[ii] = static_cast<MATH_T>(v[i]);
         } else {
           r_g[ii] = MATH_T(0);
           r_p[ii] = MATH_T(0);
@@ -346,10 +345,11 @@ struct AdamCapturableFunctor2
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-          p[i] = r_p[ii];
-          p_master[i] = r_p[ii];
-          m[i] = r_m[ii];
-          v[i] = r_v[ii];
+          g[i] = static_cast<T>(r_g[ii]);
+          p[i] = static_cast<T>(r_p[ii]);
+          p_master[i] = static_cast<T2>(r_p[ii]);
+          m[i] = static_cast<T>(r_m[ii]);
+          v[i] = static_cast<T>(r_v[ii]);
         }
       }
     }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -273,7 +273,7 @@ struct AdamCapturableFunctor2
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
     int n = tl.sizes[tensor_loc];
 
-    T2* g = (T2*)tl.addresses[0][tensor_loc];
+    T* g = (T*)tl.addresses[0][tensor_loc];
     g += chunk_idx*chunk_size;
 
     T* p = (T*)tl.addresses[1][tensor_loc];
@@ -285,8 +285,8 @@ struct AdamCapturableFunctor2
     T* v = (T*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
-    T2* p_model = (T2*)tl.addresses[4][tensor_loc];
-    p_model += chunk_idx*chunk_size;
+    T2* p_master = (T2*)tl.addresses[4][tensor_loc];
+    p_master += chunk_idx*chunk_size;
 
     n -= chunk_idx*chunk_size;
 
@@ -307,7 +307,7 @@ struct AdamCapturableFunctor2
         {
 	  g[i] = g[i] * (*inv_scale);
           r_g[ii] = g[i];
-          r_p[ii] = p[i];
+          r_p[ii] = p_master[i];
           r_m[ii] = m[i];
           r_v[ii] = v[i];
         } else {
@@ -347,7 +347,7 @@ struct AdamCapturableFunctor2
         if(i < n && i < chunk_size)
         {
           p[i] = r_p[ii];
-          p_model[i] = r_p[ii];
+          p_master[i] = r_p[ii];
           m[i] = r_m[ii];
           v[i] = r_v[ii];
         }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -273,7 +273,7 @@ struct AdamCapturableFunctor2
     int chunk_idx = tl.block_to_chunk[blockIdx.x];
     int n = tl.sizes[tensor_loc];
 
-    T2* g = (T*)tl.addresses[0][tensor_loc];
+    T2* g = (T2*)tl.addresses[0][tensor_loc];
     g += chunk_idx*chunk_size;
 
     T* p = (T*)tl.addresses[1][tensor_loc];
@@ -285,7 +285,7 @@ struct AdamCapturableFunctor2
     T* v = (T*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
-    T2* p_model = (T*)tl.addresses[4][tensor_loc];
+    T2* p_model = (T2*)tl.addresses[4][tensor_loc];
     p_model += chunk_idx*chunk_size;
 
     n -= chunk_idx*chunk_size;

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -190,6 +190,7 @@ struct AdamCapturableFunctor
         if(i < n && i < chunk_size)
         {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          g[i] = r_g[ii];
           r_p[ii] = p[i];
           r_m[ii] = m[i];
           r_v[ii] = v[i];
@@ -305,6 +306,7 @@ struct AdamCapturableFunctor2
         if(i < n && i < chunk_size)
         {
           r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          g[i] = r_g[ii];
           r_p[ii] = p_master[i];
           r_m[ii] = m[i];
           r_v[ii] = v[i];

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -239,6 +239,123 @@ struct AdamCapturableFunctor
   }
 };
 
+template<typename T, typename T2>
+struct AdamCapturableFunctor2
+{
+   __device__ __forceinline__ void operator()(
+    int chunk_size,
+    volatile int* noop_gmem,
+    TensorListMetadata<5>& tl,
+    const float beta1,
+    const float beta2,
+    const int* step,
+    const int bias_correction,
+    const float epsilon,
+    const float* lr,
+    adamMode_t mode,
+    const float decay,
+    const float* inv_scale)
+  {
+    if(*noop_gmem == 1)
+      return;
+
+    float beta1_correction = 1.0f, beta2_correction = 1.0f;
+    if (bias_correction == 1) {
+      beta1_correction = 1 - pow(beta1, *step);
+      beta2_correction = 1 - pow(beta2, *step);
+    }
+
+    int tensor_loc = tl.block_to_tensor[blockIdx.x];
+
+    // potentially use to pass in list of scalar
+    // int tensor_num = tl.start_tensor_this_launch + tensor_loc;
+
+    int chunk_idx = tl.block_to_chunk[blockIdx.x];
+    int n = tl.sizes[tensor_loc];
+
+    T2* g = (T*)tl.addresses[0][tensor_loc];
+    g += chunk_idx*chunk_size;
+
+    T* p = (T*)tl.addresses[1][tensor_loc];
+    p += chunk_idx*chunk_size;
+
+    T* m = (T*)tl.addresses[2][tensor_loc];
+    m += chunk_idx*chunk_size;
+
+    T* v = (T*)tl.addresses[3][tensor_loc];
+    v += chunk_idx*chunk_size;
+
+    T2* p_model = (T*)tl.addresses[4][tensor_loc];
+    p_model += chunk_idx*chunk_size;
+
+    n -= chunk_idx*chunk_size;
+
+    // see note in multi_tensor_scale_kernel.cu
+    for(int i_start = 0;
+            i_start < n && i_start < chunk_size;
+            i_start += blockDim.x*ILP)
+    {
+      MATH_T r_g[ILP];
+      MATH_T r_p[ILP];
+      MATH_T r_m[ILP];
+      MATH_T r_v[ILP];
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+	  g[i] = g[i] * (*inv_scale);
+          r_g[ii] = g[i];
+          r_p[ii] = p[i];
+          r_m[ii] = m[i];
+          r_v[ii] = v[i];
+        } else {
+          r_g[ii] = MATH_T(0);
+          r_p[ii] = MATH_T(0);
+          r_m[ii] = MATH_T(0);
+          r_v[ii] = MATH_T(0);
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        if(mode == ADAM_MODE_0) { // L2
+          r_g[ii] = r_g[ii] + (decay * r_p[ii]);
+          r_m[ii] = beta1 * r_m[ii] + (1-beta1) * r_g[ii];
+          r_v[ii] = beta2 * r_v[ii] + (1-beta2) * r_g[ii] * r_g[ii];
+          MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
+          MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
+          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          MATH_T update = next_m_unbiased / denom;
+          r_p[ii] = r_p[ii] - (*lr * update);
+        }
+        else { // weight decay
+          r_m[ii] = beta1 * r_m[ii] + (1-beta1) * r_g[ii];
+          r_v[ii] = beta2 * r_v[ii] + (1-beta2) * r_g[ii] * r_g[ii];
+          MATH_T next_m_unbiased = r_m[ii] / beta1_correction;
+          MATH_T next_v_unbiased = r_v[ii] / beta2_correction;
+          MATH_T denom = sqrtf(next_v_unbiased) + epsilon;
+          MATH_T update = (next_m_unbiased / denom) + (decay * r_p[ii]);
+          r_p[ii] = r_p[ii] - (*lr * update);
+        }
+      }
+#pragma unroll
+      for(int ii = 0; ii < ILP; ii++)
+      {
+        int i = i_start + threadIdx.x + ii*blockDim.x;
+        if(i < n && i < chunk_size)
+        {
+          p[i] = r_p[ii];
+          p_model[i] = r_p[ii];
+          m[i] = r_m[ii];
+          v[i] = r_v[ii];
+        }
+      }
+    }
+  }
+};
+
 void multi_tensor_adam_cuda(
   int chunk_size,
   at::Tensor noop_flag,
@@ -316,6 +433,46 @@ void multi_tensor_adam_capturable_cuda(
       (adamMode_t) mode,
       weight_decay,
       inv_scale.data_ptr<float>()); )
+
+  AT_CUDA_CHECK(cudaGetLastError());
+
+}
+
+void multi_tensor_adam_capturable_cuda_2(
+  int chunk_size,
+  at::Tensor noop_flag,
+  std::vector<std::vector<at::Tensor>> tensor_lists,
+  at::Tensor lr,
+  const float beta1,
+  const float beta2,
+  const float epsilon,
+  at::Tensor step,
+  const int mode,
+  const int bias_correction,
+  const float weight_decay,
+  at::Tensor inv_scale)
+{
+  using namespace at;
+
+  DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+    tensor_lists[0][0].scalar_type(), 0, "adam",
+    DISPATCH_DOUBLE_FLOAT_HALF_AND_BFLOAT(
+      tensor_lists[4][0].scalar_type(), 1, "adam",
+        multi_tensor_apply<5>(
+          BLOCK_SIZE,
+          chunk_size,
+          noop_flag,
+          tensor_lists,
+          AdamCapturableFunctor2<scalar_t_0, scalar_t_1>(),
+          beta1,
+          beta2,
+          step.data_ptr<int>(),
+          bias_correction,
+          epsilon,
+          lr.data_ptr<float>(),
+          (adamMode_t) mode,
+          weight_decay,
+          inv_scale.data_ptr<float>()); ))
 
   AT_CUDA_CHECK(cudaGetLastError());
 

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -297,30 +297,28 @@ struct AdamCapturableFunctor2
     {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
-      //MATH_T r_m[ILP];
-      //MATH_T r_v[ILP];
+      MATH_T r_m[ILP];
+      MATH_T r_v[ILP];
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-          //r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
-          r_g[ii] = static_cast<MATH_T>(1.01);
+          r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
           r_p[ii] = static_cast<MATH_T>(p_master[i]);
-          //r_m[ii] = static_cast<MATH_T>(m[i]);
-          //r_v[ii] = static_cast<MATH_T>(v[i]);
+          r_m[ii] = static_cast<MATH_T>(m[i]);
+          r_v[ii] = static_cast<MATH_T>(v[i]);
         } else {
           r_g[ii] = MATH_T(0);
           r_p[ii] = MATH_T(0);
-          //r_m[ii] = MATH_T(0);
-          //r_v[ii] = MATH_T(0);
+          r_m[ii] = MATH_T(0);
+          r_v[ii] = MATH_T(0);
         }
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
-        /*
         if(mode == ADAM_MODE_0) { // L2
           r_g[ii] = r_g[ii] + (decay * r_p[ii]);
           r_m[ii] = beta1 * r_m[ii] + (1-beta1) * r_g[ii];
@@ -340,8 +338,6 @@ struct AdamCapturableFunctor2
           MATH_T update = (next_m_unbiased / denom) + (decay * r_p[ii]);
           r_p[ii] = r_p[ii] - (*lr * update);
         }
-        */
-        r_p[ii] = r_p[ii] + r_g[ii];
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
@@ -352,8 +348,8 @@ struct AdamCapturableFunctor2
           g[i] = static_cast<T>(r_g[ii]);
           p[i] = static_cast<T>(r_p[ii]);
           p_master[i] = static_cast<T2>(r_p[ii]);
-          //m[i] = static_cast<T>(r_m[ii]);
-          //v[i] = static_cast<T>(r_v[ii]);
+          m[i] = static_cast<T>(r_m[ii]);
+          v[i] = static_cast<T>(r_v[ii]);
         }
       }
     }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -189,8 +189,7 @@ struct AdamCapturableFunctor
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-	  g[i] = g[i] * (*inv_scale);
-          r_g[ii] = g[i];
+          r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
           r_p[ii] = p[i];
           r_m[ii] = m[i];
           r_v[ii] = v[i];
@@ -305,8 +304,7 @@ struct AdamCapturableFunctor2
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-	  g[i] = g[i] * (*inv_scale);
-          r_g[ii] = g[i];
+          r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
           r_p[ii] = p_master[i];
           r_m[ii] = m[i];
           r_v[ii] = v[i];

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -20,7 +20,7 @@ typedef enum{
 
 using MATH_T = float;
 
-template<typename T>
+template<typename T, typename T2>
 struct AdamFunctor
 {
    __device__ __forceinline__ void operator()(
@@ -54,10 +54,10 @@ struct AdamFunctor
     T* p = (T*)tl.addresses[1][tensor_loc];
     p += chunk_idx*chunk_size;
 
-    T* m = (T*)tl.addresses[2][tensor_loc];
+    T2* m = (T2*)tl.addresses[2][tensor_loc];
     m += chunk_idx*chunk_size;
 
-    T* v = (T*)tl.addresses[3][tensor_loc];
+    T2* v = (T2*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
     n -= chunk_idx*chunk_size;
@@ -126,7 +126,7 @@ struct AdamFunctor
   }
 };
 
-template<typename T>
+template<typename T, typename T2>
 struct AdamCapturableFunctor
 {
    __device__ __forceinline__ void operator()(
@@ -166,10 +166,10 @@ struct AdamCapturableFunctor
     T* p = (T*)tl.addresses[1][tensor_loc];
     p += chunk_idx*chunk_size;
 
-    T* m = (T*)tl.addresses[2][tensor_loc];
+    T2* m = (T2*)tl.addresses[2][tensor_loc];
     m += chunk_idx*chunk_size;
 
-    T* v = (T*)tl.addresses[3][tensor_loc];
+    T2* v = (T2*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
     n -= chunk_idx*chunk_size;
@@ -279,10 +279,10 @@ struct AdamCapturableFunctor2
     T* p = (T*)tl.addresses[1][tensor_loc];
     p += chunk_idx*chunk_size;
 
-    T2* m = (T*)tl.addresses[2][tensor_loc];
+    T2* m = (T2*)tl.addresses[2][tensor_loc];
     m += chunk_idx*chunk_size;
 
-    T2* v = (T*)tl.addresses[3][tensor_loc];
+    T2* v = (T2*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
     T2* p_master = (T2*)tl.addresses[4][tensor_loc];
@@ -386,7 +386,7 @@ void multi_tensor_adam_cuda(
       chunk_size,
       noop_flag,
       tensor_lists,
-      AdamFunctor<scalar_t_0>(),
+      AdamFunctor<scalar_t_0, float>(),
       beta1,
       beta2,
       bias_correction1,
@@ -423,7 +423,7 @@ void multi_tensor_adam_capturable_cuda(
       chunk_size,
       noop_flag,
       tensor_lists,
-      AdamCapturableFunctor<scalar_t_0>(),
+      AdamCapturableFunctor<scalar_t_0, float>(),
       beta1,
       beta2,
       step.data_ptr<int>(),

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -297,28 +297,30 @@ struct AdamCapturableFunctor2
     {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
-      MATH_T r_m[ILP];
-      MATH_T r_v[ILP];
+      //MATH_T r_m[ILP];
+      //MATH_T r_v[ILP];
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-          r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          //r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          r_g[ii] = static_cast<MATH_T>(1.01);
           r_p[ii] = static_cast<MATH_T>(p_master[i]);
-          r_m[ii] = static_cast<MATH_T>(m[i]);
-          r_v[ii] = static_cast<MATH_T>(v[i]);
+          //r_m[ii] = static_cast<MATH_T>(m[i]);
+          //r_v[ii] = static_cast<MATH_T>(v[i]);
         } else {
           r_g[ii] = MATH_T(0);
           r_p[ii] = MATH_T(0);
-          r_m[ii] = MATH_T(0);
-          r_v[ii] = MATH_T(0);
+          //r_m[ii] = MATH_T(0);
+          //r_v[ii] = MATH_T(0);
         }
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
+        /*
         if(mode == ADAM_MODE_0) { // L2
           r_g[ii] = r_g[ii] + (decay * r_p[ii]);
           r_m[ii] = beta1 * r_m[ii] + (1-beta1) * r_g[ii];
@@ -338,6 +340,8 @@ struct AdamCapturableFunctor2
           MATH_T update = (next_m_unbiased / denom) + (decay * r_p[ii]);
           r_p[ii] = r_p[ii] - (*lr * update);
         }
+        */
+        r_p[ii] = r_p[ii] + r_g[ii]
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
@@ -348,8 +352,8 @@ struct AdamCapturableFunctor2
           g[i] = static_cast<T>(r_g[ii]);
           p[i] = static_cast<T>(r_p[ii]);
           p_master[i] = static_cast<T2>(r_p[ii]);
-          m[i] = static_cast<T>(r_m[ii]);
-          v[i] = static_cast<T>(r_v[ii]);
+          //m[i] = static_cast<T>(r_m[ii]);
+          //v[i] = static_cast<T>(r_v[ii]);
         }
       }
     }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -297,28 +297,30 @@ struct AdamCapturableFunctor2
     {
       MATH_T r_g[ILP];
       MATH_T r_p[ILP];
-      MATH_T r_m[ILP];
-      MATH_T r_v[ILP];
+      //MATH_T r_m[ILP];
+      //MATH_T r_v[ILP];
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
         int i = i_start + threadIdx.x + ii*blockDim.x;
         if(i < n && i < chunk_size)
         {
-          r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          //r_g[ii] = static_cast<MATH_T>(g[i]) * (*inv_scale);
+          r_g[ii] = static_cast<MATH_T>(1.01);
           r_p[ii] = static_cast<MATH_T>(p_master[i]);
-          r_m[ii] = static_cast<MATH_T>(m[i]);
-          r_v[ii] = static_cast<MATH_T>(v[i]);
+          //r_m[ii] = static_cast<MATH_T>(m[i]);
+          //r_v[ii] = static_cast<MATH_T>(v[i]);
         } else {
           r_g[ii] = MATH_T(0);
           r_p[ii] = MATH_T(0);
-          r_m[ii] = MATH_T(0);
-          r_v[ii] = MATH_T(0);
+          //r_m[ii] = MATH_T(0);
+          //r_v[ii] = MATH_T(0);
         }
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
       {
+        /*
         if(mode == ADAM_MODE_0) { // L2
           r_g[ii] = r_g[ii] + (decay * r_p[ii]);
           r_m[ii] = beta1 * r_m[ii] + (1-beta1) * r_g[ii];
@@ -338,6 +340,8 @@ struct AdamCapturableFunctor2
           MATH_T update = (next_m_unbiased / denom) + (decay * r_p[ii]);
           r_p[ii] = r_p[ii] - (*lr * update);
         }
+        */
+        r_p[ii] = r_p[ii] + r_g[ii];
       }
 #pragma unroll
       for(int ii = 0; ii < ILP; ii++)
@@ -348,8 +352,8 @@ struct AdamCapturableFunctor2
           g[i] = static_cast<T>(r_g[ii]);
           p[i] = static_cast<T>(r_p[ii]);
           p_master[i] = static_cast<T2>(r_p[ii]);
-          m[i] = static_cast<T>(r_m[ii]);
-          v[i] = static_cast<T>(r_v[ii]);
+          //m[i] = static_cast<T>(r_m[ii]);
+          //v[i] = static_cast<T>(r_v[ii]);
         }
       }
     }

--- a/csrc/multi_tensor_adam.cu
+++ b/csrc/multi_tensor_adam.cu
@@ -279,10 +279,10 @@ struct AdamCapturableFunctor2
     T* p = (T*)tl.addresses[1][tensor_loc];
     p += chunk_idx*chunk_size;
 
-    T* m = (T*)tl.addresses[2][tensor_loc];
+    T2* m = (T*)tl.addresses[2][tensor_loc];
     m += chunk_idx*chunk_size;
 
-    T* v = (T*)tl.addresses[3][tensor_loc];
+    T2* v = (T*)tl.addresses[3][tensor_loc];
     v += chunk_idx*chunk_size;
 
     T2* p_master = (T2*)tl.addresses[4][tensor_loc];
@@ -348,8 +348,8 @@ struct AdamCapturableFunctor2
           g[i] = static_cast<T>(r_g[ii]);
           p[i] = static_cast<T>(r_p[ii]);
           p_master[i] = static_cast<T2>(r_p[ii]);
-          m[i] = static_cast<T>(r_m[ii]);
-          v[i] = static_cast<T>(r_v[ii]);
+          m[i] = static_cast<T2>(r_m[ii]);
+          v[i] = static_cast<T2>(r_v[ii]);
         }
       }
     }

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -58,10 +58,6 @@ class AdamTest(unittest.TestCase):
         self.model_ = Model().cuda()
         self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
 
-        for m in self.model_.modules():
-            if m.__class__ in [torch.nn.Conv2d]:
-                m.half()
-
         self.lr = 0.00001
         params = [p for p in self.model.parameters() if p.requires_grad]
         self.optimizer = torch.optim.Adam(params, lr=self.lr)
@@ -111,7 +107,7 @@ class AdamTest(unittest.TestCase):
     
     def testGradScalerCapturable(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
-        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True, use_master=True)
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True)
         scaler = torch.cuda.amp.GradScaler(enabled=True)
         scaler_ = torch.cuda.amp.GradScaler(enabled=True)
 
@@ -143,6 +139,53 @@ class AdamTest(unittest.TestCase):
                 m = module[0]
                 m_ = module[1]
                 if isinstance(m, nn.Conv2d) or isinstance(m_, nn.Linear):
+                    torch.testing.assert_close(m.weight, m_.weight, atol=1e-3, rtol=1e-3, equal_nan=True)
+                    torch.testing.assert_close(m.weight.grad, m_.weight.grad, atol=1e-3, rtol=1e-3, equal_nan=True)
+
+            # Init for next iteration
+            self.optimizer.zero_grad()
+            optimizer_.zero_grad()
+
+            self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
+
+    def testGradScalerCapturableMaster(self):
+        # Cast conv layers to FP16
+        for m in self.model_.modules():
+            if m.__class__ in [torch.nn.Conv2d]:
+                m.half()
+        params_ = [p for p in self.model_.parameters() if p.requires_grad]
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True, use_master=True)
+        scaler = torch.cuda.amp.GradScaler(enabled=True)
+        scaler_ = torch.cuda.amp.GradScaler(enabled=True)
+
+        for i in range(100):
+            x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)
+            x_ = x.clone()
+            gt = torch.rand([32, 10]).cuda()
+            gt_ = gt.clone()
+
+            # Reference
+            with torch.cuda.amp.autocast(enabled=True):
+                y = self.model(x)
+                loss = ((gt - y) ** 2).mean()
+
+            scaler.scale(loss).backward()
+            scaler.step(self.optimizer)
+            scaler.update()
+
+            # DUT
+            with torch.cuda.amp.autocast(enabled=True):
+                y = self.model_(x)
+                loss_ = ((gt_ - y) ** 2).mean()
+
+            scaler_.scale(loss_).backward()
+            scaler_.step(optimizer_)
+            scaler_.update()
+
+            for module in zip(self.model.modules(), self.model_.modules()):
+                m = module[0]
+                m_ = module[1]
+                if isinstance(m, nn.Conv2d) or isinstance(m_, nn.Linear):
                     torch.testing.assert_close(m.weight, m_.weight.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
                     torch.testing.assert_close(m.weight.grad, m_.weight.grad.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
 
@@ -151,7 +194,7 @@ class AdamTest(unittest.TestCase):
             optimizer_.zero_grad()
 
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
-    
+
     def testNative(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False)

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -150,7 +150,7 @@ class AdamTest(unittest.TestCase):
     
     def testNative(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
-        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False)
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False, use_master=True)
 
         for i in range(100):
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -58,6 +58,13 @@ class AdamTest(unittest.TestCase):
         self.model_ = Model().cuda()
         self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
 
+        for m in self.model.modules():
+            if m.__class__ in [torch.nn.Conv2d]:
+                m.half()
+        for m in self.model_.modules():
+            if m.__class__ in [torch.nn.Conv2d]:
+                m.half()
+
         self.lr = 0.00001
         params = [p for p in self.model.parameters() if p.requires_grad]
         self.optimizer = torch.optim.Adam(params, lr=self.lr)
@@ -106,9 +113,6 @@ class AdamTest(unittest.TestCase):
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
     
     def testGradScalerCapturable(self):
-        for m in self.model_.modules():
-            if m.__class__ in [torch.nn.Conv2d]:
-                m.half()
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True, use_master=True)
         scaler = torch.cuda.amp.GradScaler(enabled=True)
@@ -152,9 +156,6 @@ class AdamTest(unittest.TestCase):
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
     
     def testNative(self):
-        for m in self.model_.modules():
-            if m.__class__ in [torch.nn.Conv2d]:
-                m.half()
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False, use_master=True)
 

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -116,7 +116,6 @@ class AdamTest(unittest.TestCase):
         scaler_ = torch.cuda.amp.GradScaler(enabled=True)
 
         for i in range(100):
-            print("Iteration", i)
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)
             x_ = x.clone()
             gt = torch.rand([32, 10]).cuda()

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -144,39 +144,13 @@ class AdamTest(unittest.TestCase):
                 loss_ = ((gt_ - y) ** 2).mean()
 
             scaler_.scale(loss_).backward()
-
-            for module in zip(self.model.modules(), self.model_.modules()):
-                m = module[0]
-                m_ = module[1]
-                if isinstance(m, nn.Conv2d):
-                    print(m)
-                    if m.weight.size() == torch.Size([16, 6, 5, 5]):
-                        print("BEFORE")
-                        print(m.weight[0][5][2][1])
-                        print(m_.weight[0][5][2][1])
-                        print(m.weight.grad[0][5][2][1])
-                        print(m_.weight.grad[0][5][2][1])
-
             scaler_.step(optimizer_)
             scaler_.update()
 
             for module in zip(self.model.modules(), self.model_.modules()):
                 m = module[0]
                 m_ = module[1]
-                if isinstance(m, nn.Conv2d):
-                    print(m)
-                    if m.weight.size() == torch.Size([16, 6, 5, 5]):
-                        print("AFTER")
-                        print(m.weight[0][5][2][1])
-                        print(m_.weight[0][5][2][1])
-                        print(m.weight.grad[0][5][2][1])
-                        print(m_.weight.grad[0][5][2][1])
-
-
-                    torch.testing.assert_close(m.weight, m_.weight.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
-                    torch.testing.assert_close(m.weight.grad, m_.weight.grad.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
-                if isinstance(m_, nn.Linear):
-                    print(m_)
+                if isinstance(m, nn.Conv2d) or isinstance(m_, nn.Linear):
                     torch.testing.assert_close(m.weight, m_.weight.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
                     torch.testing.assert_close(m.weight.grad, m_.weight.grad.float(), atol=1e-3, rtol=1e-3, equal_nan=True)
 

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -106,8 +106,11 @@ class AdamTest(unittest.TestCase):
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
     
     def testGradScalerCapturable(self):
+        for m in self.model_.modules():
+            if m.__class__ in [torch.nn.Conv2d]:
+                m.half()
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
-        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True)
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=True, use_master=True)
         scaler = torch.cuda.amp.GradScaler(enabled=True)
         scaler_ = torch.cuda.amp.GradScaler(enabled=True)
 
@@ -149,6 +152,9 @@ class AdamTest(unittest.TestCase):
             self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
     
     def testNative(self):
+        for m in self.model_.modules():
+            if m.__class__ in [torch.nn.Conv2d]:
+                m.half()
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
         optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False, use_master=True)
 

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -68,7 +68,7 @@ class AdamTest(unittest.TestCase):
 
     def testGradScaler(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
-        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False, use_master=True)
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False)
         scaler = torch.cuda.amp.GradScaler(enabled=True)
         scaler_ = torch.cuda.amp.GradScaler(enabled=True)
 
@@ -154,7 +154,7 @@ class AdamTest(unittest.TestCase):
     
     def testNative(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]
-        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False, use_master=True)
+        optimizer_ = apex.optimizers.FusedAdam(params_, lr=self.lr, capturable=False)
 
         for i in range(100):
             x = torch.rand([32, 1, 28, 28]).cuda().to(memory_format=torch.channels_last)

--- a/tests/L0/run_optimizers/test_adam.py
+++ b/tests/L0/run_optimizers/test_adam.py
@@ -121,13 +121,6 @@ class AdamTest(unittest.TestCase):
             gt = torch.rand([32, 10]).cuda()
             gt_ = gt.clone()
 
-            for module in zip(self.model.modules(), self.model_.modules()):
-                m = module[0]
-                m_ = module[1]
-                if isinstance(m, nn.Conv2d):
-                    assert(m.weight.grad is None)
-                    assert(m_.weight.grad is None)
-
             # Reference
             with torch.cuda.amp.autocast(enabled=True):
                 y = self.model(x)
@@ -157,7 +150,7 @@ class AdamTest(unittest.TestCase):
             self.optimizer.zero_grad()
             optimizer_.zero_grad()
 
-           # self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
+            self.model_.load_state_dict(copy.deepcopy(self.model.state_dict()))
     
     def testNative(self):
         params_ = [p for p in self.model_.parameters() if p.requires_grad]


### PR DESCRIPTION
This PR adds support for FP32 master weights in FusedAdam optimizer, to improve performance without affecting convergence when the model is trained with PyTorch AMP and some layers are manually cast to FP16.